### PR TITLE
sql types allowing inferrable update values

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,20 @@
 
 SQL method go code generator based on table annotations using field tags.
 
-Supported tags:
+## Table and Column definition
+### Table
+Table definition is expected as a comment of the struct type in following format:
+
+`gosqlgen:table_name: REQUIRED[FLAGS]`
+
+Where FLAGS are semicolon separated modifiers. Supported are:
+- `skip tests` - tests will be skipped for this table
+
+### Column
+Column definition is expected as a field tag (similar to json tag) in following format:
+
+`gosqlgen:"column_name: REQUIRED;sql_type:REQUIRED[FLAGS]"`
+Where FLAGS are semicolon separated modifiers. Supported are:
 - `pk` - primary key
 - `pk ai` - primary key auto incremented. Useful for inserts
 - `bk` - business key
@@ -17,25 +30,24 @@ Supported tags:
 Given following table spec:
 
 ```go
-//go:generate go run ../../cmd/main.go -driver gosqldriver_mysql -output generatedMethods.go -outputTest generatedMethods_test.go
+//go:generate go run cmd/main.go -driver gosqldriver_mysql -out generatedMethods.go -outTest generatedMethods_test.go
 package dbrepo
 
 
 // gosqlgen: users
 type User struct {
-	RawId int    `gosqlgen:"_id,pk ai"`
-	Id    string `gosqlgen:"id,bk"`
-	Name  string `gosqlgen:"name"`
+	RawId int    `gosqlgen:"_id;int;pk ai"`
+	Id    string `gosqlgen:"id;varchar(255);bk"`
+	Name  string `gosqlgen:"name;varchar(255)"`
 }
 
 // gosqlgen: addresses
 type Address struct {
-	RawId     int32        `gosqlgen:"_id,pk ai"`
-	Id        string       `gosqlgen:"id,bk"`
-	Address   string       `gosqlgen:"address,bk"`
-	UserId    int          `gosqlgen:"user_id,fk users._id"`
-	CountryId int          `gosqlgen:"country_id, fk countries._id"`
-	DeletedAt sql.NullTime `gosqlgen:"deleted_at,sd"`
+	RawId     int32        `gosqlgen:"_id;int;pk ai"`
+	Id        string       `gosqlgen:"id;int;varchar(255);bk"`
+	Address   string       `gosqlgen:"address;varchar(255);bk"`
+	UserId    int          `gosqlgen:"user_id;int;fk users._id"`
+	DeletedAt sql.NullTime `gosqlgen:"deleted_at;datetime;sd"`
 }
 ```
 

--- a/drivers/gosqldriver_mysql/driver.go
+++ b/drivers/gosqldriver_mysql/driver.go
@@ -1,10 +1,13 @@
 package gosqldrivermysql
 
 import (
+	crand "crypto/rand"
 	"fmt"
 	"go/ast"
 	"io"
+	"math/rand"
 	"slices"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -296,4 +299,62 @@ func (d driver) Delete(w io.Writer, table *gosqlgen.Table, keys []*gosqlgen.Colu
 
 	d.updateTemplate.Execute(w, data)
 	return nil
+}
+
+func randString(maxLength int) string {
+	s := crand.Text()
+	return s[:min(len(s), maxLength)]
+}
+
+func (d driver) RandValue(c *gosqlgen.Column) (any, error) {
+	st := c.SQLType
+
+	if slices.Contains([]string{"bigint", "int", "int1", "int2", "int3", "int4", "int8", "integer", "smallint", "tinyint"}, strings.ToLower(st)) {
+		return rand.Intn(128), nil
+	}
+
+	if slices.Contains([]string{"double", "float", "float4", "float8"}, strings.ToLower(st)) {
+		return rand.Float32(), nil
+	}
+
+	if slices.Contains([]string{"bool", "boolean"}, strings.ToLower(st)) {
+		return []bool{true, false}[rand.Intn(2)], nil
+	}
+
+	if slices.Contains([]string{"tinyblob", "blob", "mediumblob", "longblob", "tinytext", "text", "mediumtext", "longtext"}, strings.ToLower(st)) {
+		return randString(255), nil
+	}
+
+	if after, ok := strings.CutPrefix(strings.ToLower(st), "varchar("); ok {
+		if after, ok := strings.CutSuffix(after, ")"); ok {
+			l, err := strconv.Atoi(after)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to parse varchar length to integer")
+			}
+
+			return randString(l), nil
+
+		} else {
+			return nil, fmt.Errorf("Invalid varchar sql type. Should be in format: varchar(<length>)")
+		}
+	}
+
+	p := ""
+	if strings.HasPrefix(strings.ToLower(st), "enum(") {
+		p = st[:5]
+	}
+
+	if p != "" {
+		if after, ok := strings.CutPrefix(st, p); ok {
+			if after, ok := strings.CutSuffix(after, ")"); ok {
+				choices := strings.Split(strings.ReplaceAll(after, "'", ""), ",")
+				return strings.TrimSpace(choices[rand.Intn(len(choices))]), nil
+
+			} else {
+				return nil, fmt.Errorf("Invalid enum sql type. Should be in format: enum(<values>)")
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("Failed to generate random value for column")
 }

--- a/examples/gosqldriver_mysql/generatedMethods.go
+++ b/examples/gosqldriver_mysql/generatedMethods.go
@@ -156,7 +156,7 @@ func (t *Admin) delete(ctx context.Context, db dbExecutor) error {
 }
 
 func (t *Country) getByPrimaryKeys(ctx context.Context, db dbExecutor, _id int) error {
-	err := db.QueryRowContext(ctx, "SELECT _id, id, name, gps FROM countries WHERE _id = ?", _id).Scan(&t.RawId, &t.Id, &t.Name, &t.GPS)
+	err := db.QueryRowContext(ctx, "SELECT _id, id, name, gps, continent FROM countries WHERE _id = ?", _id).Scan(&t.RawId, &t.Id, &t.Name, &t.GPS, &t.Continent)
 
 	if err != nil {
 		return err
@@ -166,7 +166,7 @@ func (t *Country) getByPrimaryKeys(ctx context.Context, db dbExecutor, _id int) 
 }
 
 func (t *Country) getByBusinessKeys(ctx context.Context, db dbExecutor, id string) error {
-	err := db.QueryRowContext(ctx, "SELECT _id, id, name, gps FROM countries WHERE id = ?", id).Scan(&t.RawId, &t.Id, &t.Name, &t.GPS)
+	err := db.QueryRowContext(ctx, "SELECT _id, id, name, gps, continent FROM countries WHERE id = ?", id).Scan(&t.RawId, &t.Id, &t.Name, &t.GPS, &t.Continent)
 
 	if err != nil {
 		return err
@@ -176,7 +176,7 @@ func (t *Country) getByBusinessKeys(ctx context.Context, db dbExecutor, id strin
 }
 
 func (t *Country) insert(ctx context.Context, db dbExecutor) error {
-	res, err := db.ExecContext(ctx, "INSERT INTO countries (id, name, gps) VALUES (?, ?, ?)", t.Id, t.Name, t.GPS)
+	res, err := db.ExecContext(ctx, "INSERT INTO countries (id, name, gps, continent) VALUES (?, ?, ?, ?)", t.Id, t.Name, t.GPS, t.Continent)
 	if err != nil {
 		return err
 	}
@@ -191,12 +191,12 @@ func (t *Country) insert(ctx context.Context, db dbExecutor) error {
 }
 
 func (t *Country) updateByPrimaryKeys(ctx context.Context, db dbExecutor) error {
-	_, err := db.ExecContext(ctx, "UPDATE countries SET name = ?, gps = ? WHERE _id=?", t.Name, t.GPS, t.RawId)
+	_, err := db.ExecContext(ctx, "UPDATE countries SET name = ?, gps = ?, continent = ? WHERE _id=?", t.Name, t.GPS, t.Continent, t.RawId)
 	return err
 }
 
 func (t *Country) updateByBusinessKeys(ctx context.Context, db dbExecutor) error {
-	_, err := db.ExecContext(ctx, "UPDATE countries SET name = ?, gps = ? WHERE id=?", t.Name, t.GPS, t.Id)
+	_, err := db.ExecContext(ctx, "UPDATE countries SET name = ?, gps = ?, continent = ? WHERE id=?", t.Name, t.GPS, t.Continent, t.Id)
 	return err
 }
 

--- a/examples/gosqldriver_mysql/generatedMethods_test.go
+++ b/examples/gosqldriver_mysql/generatedMethods_test.go
@@ -49,7 +49,7 @@ func TestGoSQLGen_Address(t *testing.T) {
 	// Update By Primary Keys
 	// UserId
 	u = gotByPk
-	u.UserId = 104
+	u.UserId = 111
 	err = u.updateByPrimaryKeys(ctx, testDb)
 	require.NoError(t, err)
 
@@ -61,7 +61,7 @@ func TestGoSQLGen_Address(t *testing.T) {
 
 	// CountryId
 	u = gotByPk
-	u.CountryId = 113
+	u.CountryId = 49
 	err = u.updateByPrimaryKeys(ctx, testDb)
 	require.NoError(t, err)
 
@@ -74,7 +74,7 @@ func TestGoSQLGen_Address(t *testing.T) {
 	// Update By Business Keys
 	// UserId
 	u = gotByBk
-	u.UserId = 63
+	u.UserId = 39
 	err = u.updateByBusinessKeys(ctx, testDb)
 	require.NoError(t, err)
 
@@ -85,7 +85,7 @@ func TestGoSQLGen_Address(t *testing.T) {
 
 	// CountryId
 	u = gotByBk
-	u.CountryId = 12
+	u.CountryId = 121
 	err = u.updateByBusinessKeys(ctx, testDb)
 	require.NoError(t, err)
 
@@ -142,7 +142,7 @@ func TestGoSQLGen_AddressBook(t *testing.T) {
 	// Update By Primary Keys
 	// AddressId
 	u = gotByPk
-	u.AddressId = 99
+	u.AddressId = 67
 	err = u.updateByPrimaryKeys(ctx, testDb)
 	require.NoError(t, err)
 
@@ -155,7 +155,7 @@ func TestGoSQLGen_AddressBook(t *testing.T) {
 	// Update By Business Keys
 	// AddressId
 	u = gotByBk
-	u.AddressId = 248
+	u.AddressId = 114
 	err = u.updateByBusinessKeys(ctx, testDb)
 	require.NoError(t, err)
 
@@ -169,49 +169,6 @@ func TestGoSQLGen_AddressBook(t *testing.T) {
 	require.NoError(t, err)
 	gotAfterDelete := AddressBook{}
 	err = gotAfterDelete.getByPrimaryKeys(ctx, testDb, tbl_addresses_book.RawId)
-	require.Error(t, err)
-}
-
-func TestGoSQLGen_Admin(t *testing.T) {
-	ctx := t.Context()
-	var err error
-
-	// Inserts
-	tbl_users := User{}
-	err = tbl_users.insert(ctx, testDb)
-	require.NoError(t, err)
-
-	tbl_admins := Admin{RawId: tbl_users.RawId}
-	err = tbl_admins.insert(ctx, testDb)
-	require.NoError(t, err)
-
-	// Get By Primary Keys
-	gotByPk := Admin{}
-	err = gotByPk.getByPrimaryKeys(ctx, testDb, tbl_admins.RawId)
-	require.NoError(t, err)
-	assert.Equal(t, tbl_admins, gotByPk)
-
-	var gotAfterUpdate Admin
-	var u Admin
-
-	// Update By Primary Keys
-	// Name
-	u = gotByPk
-	u.Name = "5ULZ56QQD4W2NRNTHJSGGC5MJO"
-	err = u.updateByPrimaryKeys(ctx, testDb)
-	require.NoError(t, err)
-
-	gotAfterUpdate = Admin{}
-	err = gotAfterUpdate.getByPrimaryKeys(ctx, testDb, tbl_admins.RawId)
-	require.NoError(t, err)
-
-	assert.Equal(t, u.Name, gotAfterUpdate.Name)
-
-	// Delete
-	err = gotByPk.delete(ctx, testDb)
-	require.NoError(t, err)
-	gotAfterDelete := Admin{}
-	err = gotAfterDelete.getByPrimaryKeys(ctx, testDb, tbl_admins.RawId)
 	require.Error(t, err)
 }
 
@@ -243,7 +200,7 @@ func TestGoSQLGen_Country(t *testing.T) {
 	// Update By Primary Keys
 	// Name
 	u = gotByPk
-	u.Name = "456NJS3WIDIBZUJRPVXGBTCPL7"
+	u.Name = "6WR4HEQXXM2DXDWLYIK3JGAZ4M"
 	err = u.updateByPrimaryKeys(ctx, testDb)
 	require.NoError(t, err)
 
@@ -255,7 +212,7 @@ func TestGoSQLGen_Country(t *testing.T) {
 
 	// GPS
 	u = gotByPk
-	u.GPS = "RYJZSPD5EWJNS4M3POO3EPQ2DB"
+	u.GPS = "HRKWHL3RDWC4INOVS5W5BL2YKR"
 	err = u.updateByPrimaryKeys(ctx, testDb)
 	require.NoError(t, err)
 
@@ -265,10 +222,22 @@ func TestGoSQLGen_Country(t *testing.T) {
 
 	assert.Equal(t, u.GPS, gotAfterUpdate.GPS)
 
+	// Continent
+	u = gotByPk
+	u.Continent = "Europe"
+	err = u.updateByPrimaryKeys(ctx, testDb)
+	require.NoError(t, err)
+
+	gotAfterUpdate = Country{}
+	err = gotAfterUpdate.getByPrimaryKeys(ctx, testDb, tbl_countries.RawId)
+	require.NoError(t, err)
+
+	assert.Equal(t, u.Continent, gotAfterUpdate.Continent)
+
 	// Update By Business Keys
 	// Name
 	u = gotByBk
-	u.Name = "KKCG57SZDEO2BD4VGJSDLM4VGQ"
+	u.Name = "3ADOJFKPFFOBEPEUYKMUGCPIUM"
 	err = u.updateByBusinessKeys(ctx, testDb)
 	require.NoError(t, err)
 
@@ -279,7 +248,7 @@ func TestGoSQLGen_Country(t *testing.T) {
 
 	// GPS
 	u = gotByBk
-	u.GPS = "DV5BKYYFYV2GKOW4OFYERRGFCF"
+	u.GPS = "KS5K3B6SWCUYTTTDUQBY447WAR"
 	err = u.updateByBusinessKeys(ctx, testDb)
 	require.NoError(t, err)
 
@@ -287,6 +256,17 @@ func TestGoSQLGen_Country(t *testing.T) {
 	err = gotAfterUpdate.getByPrimaryKeys(ctx, testDb, tbl_countries.RawId)
 	require.NoError(t, err)
 	assert.Equal(t, u.GPS, gotAfterUpdate.GPS)
+
+	// Continent
+	u = gotByBk
+	u.Continent = "Europe"
+	err = u.updateByBusinessKeys(ctx, testDb)
+	require.NoError(t, err)
+
+	gotAfterUpdate = Country{}
+	err = gotAfterUpdate.getByPrimaryKeys(ctx, testDb, tbl_countries.RawId)
+	require.NoError(t, err)
+	assert.Equal(t, u.Continent, gotAfterUpdate.Continent)
 
 	// Delete
 	err = gotByPk.delete(ctx, testDb)
@@ -324,7 +304,7 @@ func TestGoSQLGen_User(t *testing.T) {
 	// Update By Primary Keys
 	// Name
 	u = gotByPk
-	u.Name = "EVGFZM7HY7WYQFLI65LZ325BYE"
+	u.Name = "RJZJVF4EQX5X5QGJJOTLL6HGIW"
 	err = u.updateByPrimaryKeys(ctx, testDb)
 	require.NoError(t, err)
 
@@ -337,7 +317,7 @@ func TestGoSQLGen_User(t *testing.T) {
 	// Update By Business Keys
 	// Name
 	u = gotByBk
-	u.Name = "PIWGJDAZSWGX2DLFDZUTY2ARTF"
+	u.Name = "ZCS7O6BMSVTXIVDE6IBM734BOF"
 	err = u.updateByBusinessKeys(ctx, testDb)
 	require.NoError(t, err)
 

--- a/examples/gosqldriver_mysql/tables.go
+++ b/examples/gosqldriver_mysql/tables.go
@@ -3,40 +3,52 @@ package gosqldrivermysql
 
 import "database/sql"
 
-// gosqlgen: users
-type User struct {
-	RawId int    `gosqlgen:"_id,pk ai"`
-	Id    string `gosqlgen:"id,bk"`
-	Name  string `gosqlgen:"name"`
+type Continent string
+
+var (
+	ContinentAsia   Continent = "Asia"
+	ContinentEurope Continent = "Europe"
+)
+
+type ShouldBeSkipped struct {
+	somefield int
 }
 
-// gosqlgen: admins
+// gosqlgen: users
+type User struct {
+	RawId int    `gosqlgen:"_id;int;pk ai"`
+	Id    string `gosqlgen:"id;varchar(255);bk"`
+	Name  string `gosqlgen:"name;varchar(255)"`
+}
+
+// gosqlgen: admins;skip tests
 type Admin struct {
-	RawId int    `gosqlgen:"_id,pk ai,fk users._id"`
-	Name  string `gosqlgen:"name"`
+	RawId int    `gosqlgen:"_id;int;pk ai;fk users._id"`
+	Name  string `gosqlgen:"name;varchar(255)"`
 }
 
 // gosqlgen: countries
 type Country struct {
-	RawId int    `gosqlgen:"_id,pk ai"`
-	Id    string `gosqlgen:"id,bk"`
-	Name  string `gosqlgen:"name"`
-	GPS   string `gosqlgen:"gps"`
+	RawId     int       `gosqlgen:"_id;int;pk ai"`
+	Id        string    `gosqlgen:"id;varchar(255);bk"`
+	Name      string    `gosqlgen:"name;varchar(255)"`
+	GPS       string    `gosqlgen:"gps;varchar(255)"`
+	Continent Continent `gosqlgen:"continent;enum('Asia', 'Europe')"`
 }
 
 // gosqlgen: addresses
 type Address struct {
-	RawId     int32        `gosqlgen:"_id,pk ai"`
-	Id        string       `gosqlgen:"id,bk"`
-	Address   string       `gosqlgen:"address,bk"`
-	UserId    int          `gosqlgen:"user_id,fk users._id"`
-	CountryId int          `gosqlgen:"country_id, fk countries._id"`
-	DeletedAt sql.NullTime `gosqlgen:"deleted_at,sd"`
+	RawId     int32        `gosqlgen:"_id;int;pk ai"`
+	Id        string       `gosqlgen:"id;int;varchar(255);bk"`
+	Address   string       `gosqlgen:"address;varchar(255);bk"`
+	UserId    int          `gosqlgen:"user_id;int;fk users._id"`
+	CountryId int          `gosqlgen:"country_id;int;fk countries._id"`
+	DeletedAt sql.NullTime `gosqlgen:"deleted_at;datetime;sd"`
 }
 
 // gosqlgen: addresses_book
 type AddressBook struct {
-	RawId     int    `gosqlgen:"_id,pk ai"`
-	Id        string `gosqlgen:"id,bk"`
-	AddressId int32  `gosqlgen:"address_id,fk addresses._id"`
+	RawId     int    `gosqlgen:"_id;int;pk ai"`
+	Id        string `gosqlgen:"id;varchar(255);bk"`
+	AddressId int32  `gosqlgen:"address_id;int;fk addresses._id"`
 }

--- a/sqlgen.go
+++ b/sqlgen.go
@@ -13,6 +13,8 @@ type Driver interface {
 	Create(w io.Writer, table *Table, methodName string) error
 	Update(w io.Writer, table *Table, keys []*Column, methodName string) error
 	Delete(w io.Writer, table *Table, keys []*Column, methodName string) error
+	// Generates random value given the sql type of the column
+	RandValue(c *Column) (any, error)
 }
 
 type MethodName string
@@ -121,9 +123,9 @@ var testDb *sql.DB
 		}
 
 		if !table.SkipTests {
-			err = ts.Generate(testWriter, table)
+			err = ts.Generate(testWriter, d, table)
 			if err != nil {
-				return fmt.Errorf("Failed to create TestGET template by primary keys for table %s: %w", table.Name, err)
+				return fmt.Errorf("Failed to create test template for table %s: %w", table.Name, err)
 			}
 		}
 	}


### PR DESCRIPTION
The model as it was, lacked information regarding the sql types of the column. This has proved insufficient when inferring update values for tests for enumerable strings, since golang has not builtin algebraic sum type

There are multiple changes to the API:
- field arguments `output` and `outputTest` renamed to `out` and `outTest` for brevity
- Column tag definitions must include a sql type as second field
- Separator has been changed from comma to semicolon, just as a convenience since enum definitions will contain comma separated list of fields